### PR TITLE
Add Jenkins user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:14.04
 
 MAINTAINER Jasper Behrensdorf <jasper@oddrain.de>
 
+# Add Jenkins User
+RUN useradd -r -u 980:974 -g jenkins jenkins
+
 # Matlab dependencies
 RUN apt-get update && apt-get install -y \
     libpng12-dev libfreetype6-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:14.04
 MAINTAINER Jasper Behrensdorf <jasper@oddrain.de>
 
 # Add Jenkins User
-RUN useradd -r -u 980:974 -g jenkins jenkins
+RUN useradd -r -u 980 -g jenkins jenkins
 
 # Matlab dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Jenkins calls the container with -u 980:974. This creates issues when running matlab without the uid/gid existing.